### PR TITLE
Implement docs for plugins

### DIFF
--- a/docs/plugins/cache.md
+++ b/docs/plugins/cache.md
@@ -1,0 +1,25 @@
+---
+title: Cache
+sidebar_position: 2
+---
+
+Cache plugins implement a similar interface to storage plugins, but there are a few key differences.
+
+While stores are intended to support both exact and wildcard matches, cache plugins are intended to support only exact matches. This helps keep cache plugins fast for lookups, and keeps the logic for implementing a cache simple.
+
+Store plugins _also_ do not support queries to get more than one record type for a given domain. This is, likewise, in an effort to reduce hierarchical data structures down to a single lookup. For example, the `DefaultCache` plugin stores records in a map with keys `{domain}:{recordType}`. This constrains the cache to O(1) lookups for all queries that might be run against the cache.
+
+```ts title="cache.ts"
+const cache = new DefaultCache();
+cache.set('example.com', 'A', '127.0.0.1');
+cache.append('example.com', 'A', '127.0.0.2');
+cache.get('example.com', 'A'); // ['127.0.0.1', '127.0.0.2']
+cache.delete('example.com', 'A', '127.0.0.2');
+cache.get('example.com', 'A'); // ['127.0.0.1']
+cache.delete('example.com', 'A');
+cache.get('example.com', 'A'); // null
+```
+
+For a more detailed look at `Cache` and `DefaultCache` APIs, checkout the respective documentation:
+- [Cache](https://api.dinodns.dev/classes/plugins.cache.Cache.html)
+- [DefaultCache](https://api.dinodns.dev/classes/plugins.cache.DefaultCache.html)

--- a/docs/plugins/logging.md
+++ b/docs/plugins/logging.md
@@ -1,0 +1,24 @@
+---
+title: Logging
+sidebar_position: 3
+---
+
+Logging plugins are not intended to modify the request or response in any way, but instead should be able to dispatch a log event synchronously or asynchronously. Loggers can log anything, from metrics about query volumes to individual queries themselves. Loggers can subscribe to events from the `DNSResponse` object and can log data reactively. If you're using the `ConsoleLogger`, this step is already taken care of for you if you configure the logger to log responses:
+
+```ts title="loggedServer.ts"
+const server = new DefaultServer({
+    networks: [...]
+});
+
+s.use(logger.handler);
+```
+
+When the server receives a new request that is passed to the logger, if `logRequests` is enabled, it will immediately dispatch a log. If `logResponses` is enabled, the logger will subscribe to the `DNSResponse`'s `done` event, dispatching a separate log once the answer is recorded.
+
+:::warning
+Custom or third party loggers may be more complicated in nature than the simple `ConsoleLogger`. If that's the case, it's important to make sure that all logging actions are performed asynchronously. Synchronous logs may degrade server performance.
+:::
+
+For a more detailed look at `Cache` and `DefaultCache` APIs, checkout the respective documentation:
+- [Logger](https://api.dinodns.dev/interfaces/plugins.logging.Logger.html)
+- [ConsoleLogger](https://api.dinodns.dev/classes/plugins.logging.ConsoleLogger.html)

--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -1,0 +1,24 @@
+---
+title: Storage
+sidebar_position: 1
+---
+
+A storage plugin is a database that stores zone data. The main `Store` interface is backend agnostic &mdash; stores can be backed by durable data written to disk, a database engine, or even ephemeral, in-memory structures. The `DefaultStore`, for example, is a simple in-memory implementation.
+
+Stores are generally expected to allow for direct lookups and wildcard lookups. They should implement the matching behavior described by [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034#section-4.3.3). Likewise, they should implement interfaces to retrieve all the data for a particular zone, or just one record. Most stores should also implement methods to manipulate zone data; the interface supports methods to get, set, append, and delete zone data.
+
+```ts title="storage.ts"
+const store = new DefaultStore();
+store.set('example.com', 'A', '127.0.0.1');
+store.append('example.com', 'A', '127.0.0.2'); 
+store.delete('example.com', 'A', '127.0.0.1');
+store.get('example.com', 'A'); // ['127.0.0.2']
+store.delete('example.com', 'A');
+store.delete('example.com');
+store.get('example.com', 'A') // null
+```
+
+For a more detailed look at `Store` and `DefaultStore` APIs, checkout the respective documentation:
+- [Store](https://api.dinodns.dev/classes/plugins.storage.Store.html)
+- [DefaultStore](https://api.dinodns.dev/classes/plugins.storage.DefaultStore.html)
+


### PR DESCRIPTION
This pull request includes documentation updates for the Cache, Logging, and Storage plugins. These updates provide detailed explanations and examples of how to use each plugin.

Documentation updates:

* [`docs/plugins/cache.md`](diffhunk://#diff-e8e90d9968ef81464dc87c55845fda73590c56cc1b4421193a5ea0981a66c51dR1-R25): Added a new section explaining the Cache plugin, including its intended use, differences from storage plugins, and a code example using `DefaultCache`.
* [`docs/plugins/logging.md`](diffhunk://#diff-676904e624140accb850be30bb6064d3d705cccdcda3283538d068227b905db8R1-R24): Added a new section explaining the Logging plugin, including its purpose, how loggers can be used, and a code example using `ConsoleLogger`.
* [`docs/plugins/storage.md`](diffhunk://#diff-64a22cbbe3f6eaefc507049fb3b705dc79d8deac99636a617be04f39493b79c9R1-R24): Added a new section explaining the Storage plugin, including its main interface, expected behavior, and a code example using `DefaultStore`.