### PR TITLE
Improvement/add new networks

### DIFF
--- a/docs/core-library/networks.md
+++ b/docs/core-library/networks.md
@@ -5,15 +5,56 @@ sidebar_position: 4
 
 Networks are the interfaces handle serializing queries and dispatching responses. Networks are responsible both for creating a server on their underlying protocol, and serializing messages out of the DNS wire format for their protocol. As such, defining a network typically involves defining both the base Network class, as well as a serializer.
 
-The only packaged networks that are included in DinoDNS are `DNSOverTCP` and `DNSOverUDP`. However, there is also a `DNSOverHTTP` plugin that can be installed which supports HTTP/S. This was done to reduce bundled dependencies, as the `DNSOverHTTP` class has external dependencies.
+The only packaged networks that are included in DinoDNS are `DNSOverTCP` and `DNSOverUDP`, and `DNSOverHTTP` which also provides DNS over HTTPS.
 
-## Usage
-
-Networks are passed into the server's `networks` parameter. You can pass in any number of networks, meaning if you want your server to listen on more than one port, you can simply create more than one network interface for the protocol:
+Networks are passed into the server's `networks` parameter. You can pass in any number of networks, meaning if you want your server to listen on more than one port on the same protocol, you can simply create more than one network interface for the protocol:
 
 ```ts
 new DefaultServer({
-    networks: [new DNSOverTCP('localhost', 53), new DNSOverTCP('localhost', 1053)],
+    networks: [
+        new DNSOverTCP('localhost', 53),
+        new DNSOverTCP('localhost', 1053),
+    ],
     ...
 })
+```
+
+### `DNSOverUDP`
+
+The UDP network is very low-configuration and merely accept a port and address used to start up the server. If you'd like, you can also provide a custom `serializer`, though the default serializer should fit nearly all use cases.
+
+#### Usage
+```ts
+new DNSOverUDP({ address: 'localhost', port: 1053 })
+```
+
+### `DNSOverTCP`
+
+Using the TCP network is much like the UDP network, with the added behavior that supplying an `ssl` parameter converts the network into a TLS network:
+
+#### Usage
+```ts
+const tcp = new DNSOverTCP({ address: 'localhost', port: 1053 });
+const tls = new DNSOverTCP({
+    address: 'localhost',
+    port: 1053,
+    ssl: { key: '...', cert: '...' }
+});
+console.log(tcp.networkType) // "TCP"
+console.log(tls.networkType) // "TLS"
+```
+### `DNSOverHTTP`
+
+Like the TCP network, supplying the `ssl` parameter converts the HTTP network into an HTTPS network.
+
+#### Usage
+```ts
+const http = new DNSOverHTTP({ address: 'localhost', port: 1080 });
+const https = new DNSOverHTTP({
+    address: 'localhost',
+    port: 1443,
+    ssl: { key: '...', cert: '...' }
+});
+console.log(http.networkType) // "HTTP"
+console.log(https.networkType) // "HTTPS"
 ```

--- a/docs/core-library/networks.md
+++ b/docs/core-library/networks.md
@@ -12,8 +12,8 @@ Networks are passed into the server's `networks` parameter. You can pass in any 
 ```ts
 new DefaultServer({
     networks: [
-        new DNSOverTCP('localhost', 53),
-        new DNSOverTCP('localhost', 1053),
+        new DNSOverTCP({ address: 'localhost', port: 53 }),
+        new DNSOverTCP({ address: 'localhost', port: 1053 }),
     ],
     ...
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -6035,14 +6035,6 @@
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
       "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row=="
     },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -11536,11 +11528,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
-    },
     "node_modules/pupa": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
@@ -12618,24 +12605,23 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
-      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
+      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
+        "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="
     },
     "node_modules/serve-index": {
       "version": "1.9.1",


### PR DESCRIPTION
This pull request includes several updates and additions to the `docs/core-library/networks.md` file to improve the documentation for network interfaces in DinoDNS. The changes include clarifying the available network types, updating the usage examples, and adding new sections for specific network types.

Documentation improvements:

* Clarified that `DNSOverHTTP` is included with DinoDNS and provides DNS over HTTPS.
* Updated the usage example for the `networks` parameter to show how to create multiple network interfaces for the same protocol.
* Added a new section for `DNSOverUDP` with a usage example.
* Added a new section for `DNSOverTCP` with a usage example and explanation of the `ssl` parameter for TLS support.
* Added a new section for `DNSOverHTTP` with a usage example and explanation of the `ssl` parameter for HTTPS support.