### PR TITLE
Add documentation for multithreading support

### DIFF
--- a/docs/core-library/default-server/default-server.md
+++ b/docs/core-library/default-server/default-server.md
@@ -20,3 +20,20 @@ new DefaultServer({
         res.errors.nxDomain();
     }
 });
+```
+
+## Multithreaded Support
+
+`DefaultServer` also has support for multithreading via [Node.js's cluster mode](https://nodejs.org/api/cluster.html).
+
+To enable multithreading, simply pass in the boolean `multithreaded` parameter to the constructor of the `DefaultServer` class.
+
+```ts title="multithreading.ts"
+new DefaultServer({
+    networks,
+    multithreaded: true,
+});
+```
+:::warning
+Multithreading may not work properly with all plugins. Cluster mode recreates the server in each thread and load balances between them, so each thread will have its own copy of the server and its own local state. As such, workloads that depend on changing record sets should rely on external storage plugins like the [Redis store plugin](https://github.com/jafayer/dinodns-redis-storage).
+:::


### PR DESCRIPTION
This pull request includes updates to the documentation for the `DefaultServer` class in the core library. The most significant change is the addition of a section on multithreaded support.

Documentation updates:

* [`docs/core-library/default-server/default-server.md`](diffhunk://#diff-b61e004aa9a457535d5da0c47de2d95a6a3961bd2b5b8d59c72836cf1424e3bbR23-R39): Added a new section detailing the multithreaded support available in `DefaultServer`, including an example of how to enable it and a warning about potential issues with certain plugins.