### PR TITLE
Upcoming v0.0.13 blog post announcement

### DIFF
--- a/blog/2024-10-21-docs.md
+++ b/blog/2024-10-21-docs.md
@@ -6,7 +6,7 @@ tags: [updates]
 ---
 
 Welcome to the DinoDNS docs homepage!
-
+<!-- truncate -->
 These docs are meant to provide a place for a high-level overview of how to use DinoDNS and why we built it. This blog will serve as a spot for community updates, highlights on development, and other cool things we're doing with DinoDNS!
 
 We hope to be bringing a lot more to the table in terms of documentation, development, benchmarking, and providing some real-world use cases for DinoDNS in the wild!

--- a/blog/2024-11-15-dinodns-and-multithreading.md
+++ b/blog/2024-11-15-dinodns-and-multithreading.md
@@ -1,0 +1,27 @@
+---
+slug: dinodns-and-multithreading
+title: DinoDNS v0.0.12
+authors: [jafayer]
+tags: [updates]
+preview: 
+---
+DinoDNS v0.0.12 is a major release that brings us closer to a stable launch (which we'll be versioning as 0.1.x). In this launch, we've introduced the higher-level `DinoDNS` class that builds on the DefaultServer class for low-configuration DNS servers, and multithreading support!
+<!-- truncate -->
+
+As we get closer to a stable release, we'll also be putting out some concrete performance tests. Early load tests suggest promising results compared to prior benchmarks for CoreDNS.
+
+## `DinoDNS` class
+
+The `DinoDNS` class extends off the `DefaultServer` class to provide a lower-configuration approach to building a dns server. It helps you connect your core plugins to your server without needing to reimplement the boilerplate involved in setting the server up.
+
+For more information, check out the [docs for the DinoDNS core module](/core-library/dinodns).
+
+## Multithreading support
+
+v0.0.11 introduced support for multithreading the `DefaultServer` class (and by extension the `DinoDNS` class). Multithreading is provided by Node.js's built-in [cluster](https://nodejs.org/api/cluster.html) API, and provides a per-thread instance of your DinoDNS server scaled across your machine. Early tests indicate a substantial increase in performance for workloads that support this sort of horizontal scaling.
+
+To read more about multithreading support, see the [DefaultServer docs](/core-library/default-server/).
+
+## Breaking interface changes
+
+There are several breaking interface changes introduced in v0.0.11 and v0.0.12. Notably, we've standardized the network interfaces to all use the same basic shape, and to accept an object instead of ordered parameters.

--- a/blog/2024-11-26-dinodns-and-multithreading.md
+++ b/blog/2024-11-26-dinodns-and-multithreading.md
@@ -1,14 +1,14 @@
 ---
 slug: dinodns-and-multithreading
-title: DinoDNS v0.0.12
+title: DinoDNS v0.0.13
 authors: [jafayer]
 tags: [updates]
 preview: 
 ---
-DinoDNS v0.0.12 is a major release that brings us closer to a stable launch (which we'll be versioning as 0.1.x). In this launch, we've introduced the higher-level `DinoDNS` class that builds on the DefaultServer class for low-configuration DNS servers, and multithreading support!
+DinoDNS v0.0.13 is a major release that brings us closer to a stable launch (which we'll be versioning as 0.1.x). In this launch, we've introduced the higher-level `DinoDNS` class that builds on the DefaultServer class for low-configuration DNS servers, and multithreading support!
 <!-- truncate -->
 
-As we get closer to a stable release, we'll also be putting out some concrete performance tests. Early load tests suggest promising results compared to prior benchmarks for CoreDNS.
+As we get closer to a stable release, we'll also be putting out some concrete performance tests. Early load tests suggest promising results compared to prior benchmarks for CoreDNS. Expect those in the coming weeks.
 
 ## `DinoDNS` class
 
@@ -24,4 +24,6 @@ To read more about multithreading support, see the [DefaultServer docs](/core-li
 
 ## Breaking interface changes
 
-There are several breaking interface changes introduced in v0.0.11 and v0.0.12. Notably, we've standardized the network interfaces to all use the same basic shape, and to accept an object instead of ordered parameters.
+There are several breaking interface changes introduced in v0.0.11, v0.0.12, and v0.0.13. Notably, we've standardized the network interfaces to all use the same basic shape, and to accept an object instead of ordered parameters.
+
+We're also considering changes to the `Store` interface in a coming release.

--- a/docs/core-library/networks.md
+++ b/docs/core-library/networks.md
@@ -13,7 +13,7 @@ Networks are passed into the server's `networks` parameter. You can pass in any 
 
 ```ts
 new DefaultServer({
-    networks: [new DNSOverTCP('localhost', 53), new DNSOverTCP('localhost', 1053)],
+    networks: [new DNSOverTCP({address: 'localhost', port: 53}), new DNSOverTCP({address: 'localhost', port: 1053})],
     ...
 })
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,8 +35,8 @@ const server = new DinoDNS({
     cache: cache,
     logger: logger,
     networks: [
-        new DNSOverTCP("localhost", 1053),
-        new DNSOverUDP("localhost", 1053),
+        new DNSOverTCP({address: "localhost", port: 1053}),
+        new DNSOverUDP({address: "localhost", port: 1053}),
     ]
 });
 ```
@@ -53,8 +53,8 @@ import { DNSOverTCP, DNSOverUDP } from "dinodns/networks";
 
 const server = new DefaultServer({
     networks: [
-        new DNSOverTCP("localhost", 1053),
-        new DNSOverUDP("localhost", 1053),
+        new DNSOverTCP({address: "localhost", port: 1053}),
+        new DNSOverUDP({address: "localhost", port: 1053}),
     ]
 });
 ```


### PR DESCRIPTION
This pull request includes updates to the blog documentation for DinoDNS. The changes introduce a new blog post about the DinoDNS v0.0.12 release and add a truncation marker to an existing blog post.

Updates to blog documentation:

* [`blog/2024-10-21-docs.md`](diffhunk://#diff-25ff3c70207a195fcb1fc7a96566649371fd8a1a1c5879ca46c01483b3a519a9L9-R9): Added a truncation marker to the introductory paragraph for better content management.
* [`blog/2024-11-15-dinodns-and-multithreading.md`](diffhunk://#diff-53862843f39571046e5c593755fae40cb5f53219d8b13db2698e2ae3529158f2R1-R27): Introduced a new blog post detailing the DinoDNS v0.0.12 release, which includes the new `DinoDNS` class and multithreading support, as well as breaking interface changes.